### PR TITLE
always convert image to RGB before checking RGB colors

### DIFF
--- a/sloth.py
+++ b/sloth.py
@@ -423,6 +423,8 @@ class ShaderGenerator(dict):
 
 			gray = ( img.mode in ("L", "LA") )
 
+			img = img.convert("RGB")
+
 			# check for RGB images with no actual non-gray color
 			if not gray:
 				colors = img.getcolors(maxcolors = 256)


### PR DESCRIPTION
Previously, Sloth was assuming the given addition texture was an RGB one. By the way, some PNG crusher use index PNG abilities to losslessly save space when possible. Because of that, Sloth crashes.

This code is faulty, it crashes on `if not rgb[0] == rgb[1] == rgb[2]`:

```python
if shader["addition"]:
	img = Image.open(shader["abspath"]+os.path.sep+shader["addition"]+shader["ext"]["addition"], "r")

	gray = ( img.mode in ("L", "LA") )

	# check for RGB images with no actual non-gray color
	if not gray:
		colors = img.getcolors(maxcolors = 256)
		if colors:
			gray = True
			for _, rgb in colors:
				if not rgb[0] == rgb[1] == rgb[2]:
					gray = False
					break

	shader["meta"]["additionGrayscale"] = gray
```

Here is some experiments I did:

```python
In [1]: from PIL import Image
In [2]: img = Image.open("…/tex-pk02_src.dpkdir/textures/shared_pk02_src/wall02c_a.png")
In [7]: _, rgb = img.getcolors(maxcolors = 256)[0]
In [8]: rgb
Out[8]: 0
In [9]: rgb[0]
TypeError                                 Traceback (most recent call last)
----> 1 rgb[0]

TypeError: 'int' object is not subscriptable

In [13]: img = Image.open("…/tex-pk02_source.pk3dir/textures/shared_pk02_src/wall02c_a.tga")
In [14]: img.getcolors()[0]
Out[14]: (44, (255, 255, 255))
In [15]: img = Image.open("…/tex-pk02_src.dpkdir/textures/shared_pk02_src/wall02c_a.png")
In [16]: img.getcolors()[0]
Out[16]: (23, 0)
In [17]: img = img.convert("RGB")
In [18]: img.getcolors()[0]
Out[18]: (44, (255, 255, 255))
In [19]: img = Image.open("…/tex-pk02_src.dpkdir/textures/shared_pk02_src/wall02c_a.png").convert("RGB")
In [20]: img.getcolors()[0]
Out[20]: (44, (255, 255, 255))
In [24]: _, rgb = img.getcolors()[0]
In [25]: rgb
Out[25]: (255, 255, 255)
```

The fix is easy:

```diff
if shader["addition"]:
-	img = Image.open(shader["abspath"]+os.path.sep+shader["addition"]+shader["ext"]["addition"], "r")
+	img = Image.open(shader["abspath"]+os.path.sep+shader["addition"]+shader["ext"]["addition"], "r").convert("RGB")

	gray = ( img.mode in ("L", "LA") )

	# check for RGB images with no actual non-gray color
	if not gray:
		colors = img.getcolors(maxcolors = 256)
		if colors:
			gray = True
			for _, rgb in colors:
				if not rgb[0] == rgb[1] == rgb[2]:
					gray = False
					break

	shader["meta"]["additionGrayscale"] = gray
```