### PR TITLE
argparse: tell default renderer

### DIFF
--- a/sloth.py
+++ b/sloth.py
@@ -975,7 +975,8 @@ if __name__ == "__main__":
 	                help="Use renderer features of the Daemon engine. Makes the shaders incompatible with XreaL and Quake3.")
 
 	gm.add_argument("--xreal", action="store_true",
-	               help="Use renderer features of the XreaL engine. Makes the shaders incompatible with Quake3. This is the default.")
+	               default="--" + ShaderGenerator.defaultRenderer,
+	               help="Use renderer features of the XreaL engine. Makes the shaders incompatible with Quake3.")
 
 	gm.add_argument("--quake3", action="store_true",
 	                help="Use renderer features of the vanilla Quake3 engine only.")

--- a/sloth.py
+++ b/sloth.py
@@ -975,8 +975,8 @@ if __name__ == "__main__":
 	                help="Use renderer features of the Daemon engine. Makes the shaders incompatible with XreaL and Quake3.")
 
 	gm.add_argument("--xreal", action="store_true",
-	               default="--" + ShaderGenerator.defaultRenderer,
-	               help="Use renderer features of the XreaL engine. Makes the shaders incompatible with Quake3.")
+	                default="--" + ShaderGenerator.defaultRenderer,
+	                help="Use renderer features of the XreaL engine. Makes the shaders incompatible with Quake3.")
 
 	gm.add_argument("--quake3", action="store_true",
 	                help="Use renderer features of the vanilla Quake3 engine only.")


### PR DESCRIPTION
That's a very minor change, it makes built-in help displaying this:

```
Renderers:
  --daemon              Use renderer features of the Daemon engine. Makes the
                        shaders incompatible with XreaL and Quake3. (default:
                        False)
  --xreal               Use renderer features of the XreaL engine. Makes the
                        shaders incompatible with Quake3. (default: --xreal)
  --quake3              Use renderer features of the vanilla Quake3 engine
                        only. (default: False)
```

instead of this:

```
Renderers:
  --daemon              Use renderer features of the Daemon engine. Makes the
                        shaders incompatible with XreaL and Quake3. (default:
                        False)
  --xreal               Use renderer features of the XreaL engine. Makes the
                        shaders incompatible with Quake3. This is the default.
                        (default: False)
  --quake3              Use renderer features of the vanilla Quake3 engine
                        only. (default: False)
```

Notice the weird “_This is the default. (default: False)_” that was there before.