### PR TITLE
blacklist image source files like xcf and other formats, fix #1

### DIFF
--- a/sloth.py
+++ b/sloth.py
@@ -49,6 +49,14 @@ class ShaderGenerator(dict):
 	# basename of the per-set option file
 	defaultSlothFile = "options"+slothFileExt
 
+	# common file extensions for image source
+	extBlackList = \
+	[
+		".ora",
+		".psd",
+		".xcf",
+	]
+
 
 	def __init__(self, verbosity = 0):
 		self.verbosity        = verbosity
@@ -562,6 +570,11 @@ class ShaderGenerator(dict):
 		# retrieve all maps by type
 		for filename in filelist:
 			mapname, ext = os.path.splitext(filename)
+
+			# check if this file extension is not among known unsupported ones
+			if ext.lower() in self.extBlackList:
+				self.verbose(filename + ": Unsupported format")
+				continue	
 
 			if ext == self.slothFileExt:
 				slothfiles.add(mapname)


### PR DESCRIPTION
fix #1
obsolete #3

I've heard there is many improvements doable in Sloth, by I feel that is up to other pull requests.
#3 is open since more than two years just because those extra features are waiting for.

The real need is to enable Sloth to run on Unvanquished asset repositories, which is not yet true for a couple of them.

Even if we support one day crn detection with some fallback, even if we support format priority one day (like the engine does), even if we implement any other improvement we can dream off, I see really no reason to not simply blacklist xcf files and stuff like that, those are never meant to be used in game or mapping tools or anything like that, so sloth can just ignore them.