### PR TITLE
configparser deprecated readfp() for read_file()

### DIFF
--- a/sloth.py
+++ b/sloth.py
@@ -308,7 +308,7 @@ class ShaderGenerator(dict):
 				config.read_string(path.read())
 			else:
 				with open(path, "r") as fp:
-					config.readfp(fp)
+					config.read_file(fp)
 		except IOError:
 			self.error("Couldn't read "+path+".")
 			return


### PR DESCRIPTION
otherwise we get this:

```py
sloth.py:303: DeprecationWarning: This method will be removed in future versions.  Use 'parser.read_file()' instead.
  config.readfp(fp)
```