### PR TITLE
generate culled and non-culled variants of translucent textures

### DIFF
--- a/sloth.py
+++ b/sloth.py
@@ -525,7 +525,6 @@ class ShaderGenerator(dict):
 		if shader["meta"]["diffuseAlpha"]:
 			keywords.setdefault("surfaceparm", set())
 			keywords["surfaceparm"].add("trans")
-			keywords["cull"] = {"none"}
 
 			if options["alphaShadows"]:
 				keywords["surfaceparm"].add("alphashadow")
@@ -606,6 +605,37 @@ class ShaderGenerator(dict):
 		# add new shaders (adds back original shader under new name, without addition map)
 		self.sets[setname].update(newShaders)
 
+	def __expandTranslucentShaders(self, setname):
+		"Replaces every shader with a diffuse map having an alpha channel with a set of shaders"
+		"with culling enabled or disabled."
+
+		newShaders = dict()
+		delNames   = set()
+
+		for shadername in self.sets[setname]:
+			shader = self.sets[setname][shadername]
+
+			if shader["meta"]["diffuseAlpha"]:
+				# mark original shader for deletion
+				delNames.add(shadername)
+
+				shader = self.sets[setname][shadername]
+
+				# disable culling (two-sided shader), use the original name
+				newShader = copy.deepcopy(shader)
+				newShader["keywords"]["cull"] = {"none"}
+				newShaders[shadername] = newShader
+
+				# keep culling disabled (one-sided shader), append "_onesided" to its name
+				newShader = copy.deepcopy(shader)
+				newShaders[shadername + "_onesided"] = newShader
+
+		# delete old reference to the original
+		for shadername in delNames:
+			self.sets[setname].pop(shadername)
+
+		# add new shaders
+		self.sets[setname].update(newShaders)
 
 	def __readAliases(self, path):
 		filepath = os.path.join(path,"sloth-alias.txt")
@@ -723,6 +753,8 @@ class ShaderGenerator(dict):
 
 		# expand relevant shaders into multiple light emitting ones
 		self.__expandLightShaders(setname)
+
+		self.__expandTranslucentShaders(setname)
 
 		numShaders = str(len(self.sets[setname]))
 


### PR DESCRIPTION
Generate culled and non-culled variants of translucent textures.

A known way to workaround broken deluxe maps on translucent textures is to cull the translucent texture.

For example culling the trak5 glass workarounds this bug:

- https://github.com/Unvanquished/Unvanquished/issues/2908

Sloth disabled culling on translucent textures, and it makes sense when the texture is within the world, like when used on a glass door, or that you can walk both outside and inside a building having windows made of glass.

But when the glass surface is sealing the world and the other side of the glass is the void, we can cull those textures, and it happens that culling such textures helps `q3map2` to not do garbage with deluxe mapping (maybe q3map2 is trying to blend the deluxemaps of both side into one).

So this code generates an extra `_cull` variant, here an example with trak5 glass:

```
textures/shared_trak5/glass
{
	qer_editorImage textures/shared_trak5_src/glass_d
	qer_trans 0.50

	cull                none
	surfaceparm         trans

	{
		diffuseMap textures/shared_trak5_src/glass_d
		blend blend
	}
}

textures/shared_trak5/glass_cull
{
	qer_editorImage textures/shared_trak5_src/glass_d
	qer_trans 0.50

	surfaceparm         trans

	{
		diffuseMap textures/shared_trak5_src/glass_d
		blend blend
	}
}
```